### PR TITLE
Fix: Correct day calculation in counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,7 +31,17 @@ function updateCounter() {
 
     const years = Math.floor(diff / (1000 * 60 * 60 * 24 * 365.25));
     const months = Math.floor(diff / (1000 * 60 * 60 * 24 * 30.44)) % 12;
-    const days = Math.floor(diff / (1000 * 60 * 60 * 24)) % 30;
+
+    // Calculate the date after subtracting the full years and months
+    let tempDate = new Date(birthDate);
+    tempDate.setFullYear(tempDate.getFullYear() + years);
+    tempDate.setMonth(tempDate.getMonth() + months);
+
+    // Calculate the difference in days between now and this tempDate
+    // This will give the remaining days more accurately
+    const daysDiff = now - tempDate;
+    const days = Math.floor(daysDiff / (1000 * 60 * 60 * 24));
+
     const hours = Math.floor(diff / (1000 * 60 * 60)) % 24;
     const minutes = Math.floor(diff / (1000 * 60)) % 60;
     const seconds = Math.floor(diff / 1000) % 60;


### PR DESCRIPTION
The previous implementation of the counter used modulo 30 to calculate the number of days, which is incorrect as months have varying lengths.

This change updates the `updateCounter` function in `script.js` to accurately calculate the remaining days after accounting for the full years and months that have passed since the birth date.

With this fix, the counter now correctly displays the number of days. For example, for a birth date of May 5, 1993, and a current date of June 1, 2024, the counter correctly shows 27 days (along with 31 years and 0 months).